### PR TITLE
Allow loader to be used on traditional Unix-like systems

### DIFF
--- a/Loader/Library/CopyService.cs
+++ b/Loader/Library/CopyService.cs
@@ -52,6 +52,36 @@ public class CopyService
     private static string GetCuraLocation(string? version) =>
         Path.Join(GetAppDataDirectory(), "cura", version);
 
+    private static bool IsUnixLike()
+    {
+        // Should return true if the system behaves like a
+        // "traditional" Unix system.
+        return (OperatingSystem.IsLinux() || OperatingSystem.IsFreeBSD());
+    }
+
+    private static string GetUnixAppDataDirectory()
+    {
+        string? xdgDataHomeMaybe = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+
+        if (xdgDataHomeMaybe == null)
+        {
+            string? homeMaybe = Environment.GetEnvironmentVariable("HOME");
+
+            if (homeMaybe == null)
+            {
+                throw new InvalidOperationException($"Environment variable HOME does not exist!.");
+            }
+            else
+            {
+                return Path.Join(homeMaybe, ".local", "share");
+            }
+        }
+        else
+        {
+            return xdgDataHomeMaybe;
+        }
+    }
+
     private static string GetAppDataDirectory()
     {
         if (OperatingSystem.IsWindows())
@@ -62,6 +92,11 @@ public class CopyService
         if (OperatingSystem.IsMacOS())
         {
             return Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support");
+        }
+
+        if (IsUnixLike())
+        {
+            return GetUnixAppDataDirectory();
         }
 
         throw new InvalidOperationException($"Unknown operating system.");

--- a/Loader/Library/CopyService.cs
+++ b/Loader/Library/CopyService.cs
@@ -59,29 +59,6 @@ public class CopyService
         return (OperatingSystem.IsLinux() || OperatingSystem.IsFreeBSD());
     }
 
-    private static string GetUnixAppDataDirectory()
-    {
-        string? xdgDataHomeMaybe = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
-
-        if (xdgDataHomeMaybe == null)
-        {
-            string? homeMaybe = Environment.GetEnvironmentVariable("HOME");
-
-            if (homeMaybe == null)
-            {
-                throw new InvalidOperationException($"Environment variable HOME does not exist!.");
-            }
-            else
-            {
-                return Path.Join(homeMaybe, ".local", "share");
-            }
-        }
-        else
-        {
-            return xdgDataHomeMaybe;
-        }
-    }
-
     private static string GetAppDataDirectory()
     {
         if (OperatingSystem.IsWindows())
@@ -96,7 +73,7 @@ public class CopyService
 
         if (IsUnixLike())
         {
-            return GetUnixAppDataDirectory();
+            return Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         }
 
         throw new InvalidOperationException($"Unknown operating system.");

--- a/Loader/Library/Directories.cs
+++ b/Loader/Library/Directories.cs
@@ -9,6 +9,6 @@ public static class Directories
     public readonly static string Quality = "quality";
     public readonly static string Intent = "intent";
 
-    public static string FormatIntent(Filaments material) => $"{Intent}\\{material}";
-    public static string FormatQuality(Filaments material, double size) => $"{Quality}\\{material}\\{size}";
+    public static string FormatIntent(Filaments material) => Path.Join(Intent, material.ToString());
+    public static string FormatQuality(Filaments material, double size) => Path.Join(Quality, material.ToString(), size.ToString());
 }


### PR DESCRIPTION
There are two main changes here:

1) Modifying GetAppDataDirectory() to return a reasonable value for Unix-like systems. Following Cura's behavior, this directory is either `$XDG_DATA_HOME`, if it exists, or `$HOME/.local/share` otherwise. For now, only Linux and FreeBSD are supported, since this is what the .NET runtime supports, but this can be updated by modifying the `IsUnixLike()` method.

2) Eliminating the assumption that a backslash is the path separator, which is true on Windows but not on macOS or on typical Unices. Instead, `Path.Join()` is used consistently to avoid this assumption. Note that this change should benefit Mac users as well.