### PR TITLE
use default fan speed for 0.8 nozzle

### DIFF
--- a/cura/variants/flsun_v400_0.8.inst.cfg
+++ b/cura/variants/flsun_v400_0.8.inst.cfg
@@ -10,8 +10,6 @@ hardware_type = nozzle
 
 [values]
 brim_width = 7
-cool_fan_speed = 7
-cool_fan_speed_max = 100
 cool_min_speed = 5
 infill_overlap = 0
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'gyroid'


### PR DESCRIPTION
The value defined for cool_fan_speed was too low. By removing it, the default value for the given material is used.