### PR TITLE
This updates the setting version from 20 to 22.

### DIFF
--- a/cura/intent/PETG/flsun_v400_0.4_PETG_Draft_Print_Quick.inst.cfg
+++ b/cura/intent/PETG/flsun_v400_0.4_PETG_Draft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 intent_category = quick
 quality_type = draft

--- a/cura/intent/PETG/flsun_v400_0.4_PETG_Fast_Print_Accurate.inst.cfg
+++ b/cura/intent/PETG/flsun_v400_0.4_PETG_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/cura/intent/PETG/flsun_v400_0.4_PETG_Fast_Visual.inst.cfg
+++ b/cura/intent/PETG/flsun_v400_0.4_PETG_Fast_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 quality_type = fast
 intent_category = visual

--- a/cura/intent/PETG/flsun_v400_0.4_PETG_High_Visual.inst.cfg
+++ b/cura/intent/PETG/flsun_v400_0.4_PETG_High_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 quality_type = high
 intent_category = visual

--- a/cura/intent/PETG/flsun_v400_0.4_PETG_Normal_Quality_Accurate.inst.cfg
+++ b/cura/intent/PETG/flsun_v400_0.4_PETG_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/cura/intent/PETG/flsun_v400_0.4_PETG_Normal_Visual.inst.cfg
+++ b/cura/intent/PETG/flsun_v400_0.4_PETG_Normal_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 quality_type = normal
 intent_category = visual

--- a/cura/intent/PETG/flsun_v400_0.4_PETG_VeryDraft_Print_Quick.inst.cfg
+++ b/cura/intent/PETG/flsun_v400_0.4_PETG_VeryDraft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 intent_category = quick
 quality_type = verydraft

--- a/cura/intent/PLA/flsun_v400_0.4_PLA_Draft_Print_Quick.inst.cfg
+++ b/cura/intent/PLA/flsun_v400_0.4_PLA_Draft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 intent_category = quick
 quality_type = draft

--- a/cura/intent/PLA/flsun_v400_0.4_PLA_Fast_Print_Accurate.inst.cfg
+++ b/cura/intent/PLA/flsun_v400_0.4_PLA_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/cura/intent/PLA/flsun_v400_0.4_PLA_Fast_Visual.inst.cfg
+++ b/cura/intent/PLA/flsun_v400_0.4_PLA_Fast_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 quality_type = fast
 intent_category = visual

--- a/cura/intent/PLA/flsun_v400_0.4_PLA_High_Visual.inst.cfg
+++ b/cura/intent/PLA/flsun_v400_0.4_PLA_High_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 quality_type = high
 intent_category = visual

--- a/cura/intent/PLA/flsun_v400_0.4_PLA_Normal_Quality_Accurate.inst.cfg
+++ b/cura/intent/PLA/flsun_v400_0.4_PLA_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/cura/intent/PLA/flsun_v400_0.4_PLA_Normal_Visual.inst.cfg
+++ b/cura/intent/PLA/flsun_v400_0.4_PLA_Normal_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 quality_type = normal
 intent_category = visual

--- a/cura/intent/PLA/flsun_v400_0.4_PLA_VeryDraft_Print_Quick.inst.cfg
+++ b/cura/intent/PLA/flsun_v400_0.4_PLA_VeryDraft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = intent
 intent_category = quick
 quality_type = verydraft

--- a/cura/quality/ABS/0.25/flsun_v400_0.25_ABS_Normal_Quality.inst.cfg
+++ b/cura/quality/ABS/0.25/flsun_v400_0.25_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 0

--- a/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_Draft_Print.inst.cfg
+++ b/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = draft
 weight = -2

--- a/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_Fast_Print.inst.cfg
+++ b/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = fast
 weight = -1

--- a/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_High_Quality.inst.cfg
+++ b/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = high
 weight = 1

--- a/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_Normal_Quality.inst.cfg
+++ b/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 1

--- a/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_VeryDraft_Print.inst.cfg
+++ b/cura/quality/ABS/0.4/flsun_v400_0.4_ABS_VeryDraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = verydraft
 weight = -3

--- a/cura/quality/ABS/0.6/flsun_v400_0.6_ABS_Fast_Print.inst.cfg
+++ b/cura/quality/ABS/0.6/flsun_v400_0.6_ABS_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = fast
 weight = -1

--- a/cura/quality/ABS/0.6/flsun_v400_0.6_ABS_High_Quality.inst.cfg
+++ b/cura/quality/ABS/0.6/flsun_v400_0.6_ABS_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = high
 weight = 1

--- a/cura/quality/ABS/0.6/flsun_v400_0.6_ABS_Normal_Quality.inst.cfg
+++ b/cura/quality/ABS/0.6/flsun_v400_0.6_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 1

--- a/cura/quality/ABS/0.8/flsun_v400_0.8_ABS_Draft_Print.inst.cfg
+++ b/cura/quality/ABS/0.8/flsun_v400_0.8_ABS_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = draft
 weight = -2

--- a/cura/quality/ABS/0.8/flsun_v400_0.8_ABS_Superdraft_Print.inst.cfg
+++ b/cura/quality/ABS/0.8/flsun_v400_0.8_ABS_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = superdraft
 weight = -4

--- a/cura/quality/ABS/0.8/flsun_v400_0.8_ABS_Verydraft_Print.inst.cfg
+++ b/cura/quality/ABS/0.8/flsun_v400_0.8_ABS_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = verydraft
 weight = -3

--- a/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_Draft_Print.inst.cfg
+++ b/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = draft
 weight = -2

--- a/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_Fast_Print.inst.cfg
+++ b/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = fast
 weight = -1

--- a/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_High_Quality.inst.cfg
+++ b/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = high
 weight = 1

--- a/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_Normal_Quality.inst.cfg
+++ b/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 1

--- a/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_VeryDraft_Print.inst.cfg
+++ b/cura/quality/PETG/0.4/flsun_v400_0.4_PETG_VeryDraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = verydraft
 weight = -3

--- a/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_Draft_Print.inst.cfg
+++ b/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = draft
 weight = -2

--- a/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_Fast_Print.inst.cfg
+++ b/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = fast
 weight = -1

--- a/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_High_Quality.inst.cfg
+++ b/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = high
 weight = 1

--- a/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_Normal_Quality.inst.cfg
+++ b/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 1

--- a/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_VeryDraft_Print.inst.cfg
+++ b/cura/quality/PETG/0.6/flsun_v400_0.6_PETG_VeryDraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = verydraft
 weight = -3

--- a/cura/quality/PLA/0.25/flsun_v400_0.25_PLA_Normal_Quality.inst.cfg
+++ b/cura/quality/PLA/0.25/flsun_v400_0.25_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 0

--- a/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_Draft_Print.inst.cfg
+++ b/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = draft
 weight = -2

--- a/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_Fast_Print.inst.cfg
+++ b/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = fast
 weight = -1

--- a/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_High_Quality.inst.cfg
+++ b/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = high
 weight = 1

--- a/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_Normal_Quality.inst.cfg
+++ b/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 1

--- a/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_VeryDraft_Print.inst.cfg
+++ b/cura/quality/PLA/0.4/flsun_v400_0.4_PLA_VeryDraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = verydraft
 weight = -3

--- a/cura/quality/PLA/0.6/flsun_v400_0.6_PLA_Fast_Print.inst.cfg
+++ b/cura/quality/PLA/0.6/flsun_v400_0.6_PLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = fast
 weight = -1

--- a/cura/quality/PLA/0.6/flsun_v400_0.6_PLA_High_Quality.inst.cfg
+++ b/cura/quality/PLA/0.6/flsun_v400_0.6_PLA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = high
 weight = 1

--- a/cura/quality/PLA/0.6/flsun_v400_0.6_PLA_Normal_Quality.inst.cfg
+++ b/cura/quality/PLA/0.6/flsun_v400_0.6_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 1

--- a/cura/quality/PLA/0.8/flsun_v400_0.8_PLA_Draft_Print.inst.cfg
+++ b/cura/quality/PLA/0.8/flsun_v400_0.8_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = draft
 weight = -2

--- a/cura/quality/PLA/0.8/flsun_v400_0.8_PLA_Superdraft_Print.inst.cfg
+++ b/cura/quality/PLA/0.8/flsun_v400_0.8_PLA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = superdraft
 weight = -4

--- a/cura/quality/PLA/0.8/flsun_v400_0.8_PLA_Verydraft_Print.inst.cfg
+++ b/cura/quality/PLA/0.8/flsun_v400_0.8_PLA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = verydraft
 weight = -3

--- a/cura/quality/TPU/0.4/flsun_v400_0.4_TPU_Draft_Print.inst.cfg
+++ b/cura/quality/TPU/0.4/flsun_v400_0.4_TPU_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = draft
 weight = -2

--- a/cura/quality/TPU/0.4/flsun_v400_0.4_TPU_Fast_Print.inst.cfg
+++ b/cura/quality/TPU/0.4/flsun_v400_0.4_TPU_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = fast
 weight = -1

--- a/cura/quality/TPU/0.4/flsun_v400_0.4_TPU_Normal_Quality.inst.cfg
+++ b/cura/quality/TPU/0.4/flsun_v400_0.4_TPU_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 0

--- a/cura/quality/flsun_v400_global_Draft_Quality.inst.cfg
+++ b/cura/quality/flsun_v400_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = draft
 weight = -2

--- a/cura/quality/flsun_v400_global_Fast_Quality.inst.cfg
+++ b/cura/quality/flsun_v400_global_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = fast
 weight = -1

--- a/cura/quality/flsun_v400_global_High_Quality.inst.cfg
+++ b/cura/quality/flsun_v400_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = high
 weight = 1

--- a/cura/quality/flsun_v400_global_Normal_Quality.inst.cfg
+++ b/cura/quality/flsun_v400_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = normal
 weight = 0

--- a/cura/quality/flsun_v400_global_Superdraft_Quality.inst.cfg
+++ b/cura/quality/flsun_v400_global_Superdraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = superdraft
 weight = -4

--- a/cura/quality/flsun_v400_global_Verydraft_Quality.inst.cfg
+++ b/cura/quality/flsun_v400_global_Verydraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = flsun_v400
 
 [metadata]
-setting_version = 20
+setting_version = 22
 type = quality
 quality_type = verydraft
 weight = -3


### PR DESCRIPTION
Cura 5.4 expects the setting version `22` for quality and intent files.
Upon reading files with version `20`, cura will trigger a configuration upgrade
task during cura start up.

On linux, this upgrade process seems to be broken. The files
`quality/flsun_v400_global_*.inst.cfg` will get truncated to 0 bytes during the upgrade task.

Restarting cura afterwards with the truncated 0 byte files results in a cura program crash during cura start up.

To prevent the bogus upgrade task from cura to truncate the global quality files,
this manually upgrades the setting_version in all relevant places.

The currently expected versions for the files can be seen in Cura's version upgrade code:
https://github.com/Ultimaker/Cura/blob/fbfb4b82dd17b9173a23b0d4ac671994f1318075/plugins/VersionUpgrade/VersionUpgrade53to54/__init__.py#L16C29-L16C29